### PR TITLE
Fix sidebar position for firefox

### DIFF
--- a/dashboard.css
+++ b/dashboard.css
@@ -14,7 +14,6 @@ body {
 
 .sidebar {
   position: fixed;
-  top: 0;
   bottom: 0;
   left: 0;
   z-index: 100; /* Behind the navbar */
@@ -25,7 +24,6 @@ body {
 .sidebar-sticky {
   position: -webkit-sticky;
   position: sticky;
-  top: 48px; /* Height of navbar */
   height: calc(100vh - 48px);
   padding-top: .5rem;
   overflow-x: hidden;


### PR DESCRIPTION
I noticed in Firefox the position of the sidebar was incorrect. Hiding the **Instances** menu item as shown below.

![Screenshot_2019-03-19_11-33-08](https://user-images.githubusercontent.com/57889/54624331-2bcea680-4a3b-11e9-8cb7-15164a889313.png)

I've tested this fix on Firefox and Chrome.